### PR TITLE
add support for custom host name

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,13 @@ module.exports = function(b, opts) {
   var deferred = opts.deferred;
 
   var port = 0;
+  var hostname = opts.host || 'document.location.hostname'
   var  wss = new WSServer({ port }, function() {
     port = this.address().port;
     console.log("WS server listening on ", port);
 
       //late plugin registration, it's okay
-    var prefix = `(${connect})(document.location.hostname, ${port});`;
+    var prefix = `(${connect})('${hostname}', ${port});`;
     b.plugin(wrap, {prefix});
   });
 
@@ -63,5 +64,3 @@ module.exports = function(b, opts) {
   });
 
 }
-
-


### PR DESCRIPTION
I am using this library in a project that creates an iframe dynamically and set's the content via a blob url

```js
// ...
    var blob = new Blob([content], { type : 'text/html' })
    iframe.src = URL.createObjectURL(blob)
    document.body.appendChild(iframe)
// ...
```

The html `content` contains a script tag to the javascript bundle that should be loaded which will have the prepended websocket snippet to connect to the browserify-reload server.

**...unfortunately, the `document.location.hostname === ""` on a blob url, which breaks the live-reload feature.**

This PR is meant to fix that :-) 